### PR TITLE
Add permission check to unban.js

### DIFF
--- a/commands/unban.js
+++ b/commands/unban.js
@@ -2,14 +2,17 @@ const Discord = require('discord.js')
 
 module.exports.run = async (client, message, args, guild) => {
   
-  let userid = message.mentions.users.first().id
+  let userid = message.mentions.users.first().id || args[0]
   if(!userid) return message.reply('error?')
-  
-  // Unban a user by ID (or with a user/guild member object)
-guild.unban(userid)
-  .then(user => message.channel.send(`Unbanned ${user.username} from ${guild}`))
-  .catch(console.error);
-}
+  if(!message.member.hasPermission("BAN_MEMBERS")) return message.reply('you don\'t have permission to use this command.')
+  const guildbans = await message.guild.fetchBans();
+  if(!guildbans.get(userid)) return message.reply('this user isn\'t banned.')
+  // Unban a user by ID (or with a user/guild member object) 
+  const target = userid
+  guild.unban(target)
+    .then(user => message.channel.send(`Unbanned ${user.username} from ${guild}`))
+    .catch(console.error);
+  }
 module.exports.help = {
   "name": "unban"
 }


### PR DESCRIPTION
Unban.js doesn't check for permissions from the user before unbanning that user, so this PR should fix that problem.
also, it doesn't check if that user is unbanned, so both of these problems will throw an API error and will probably break the bot. I will be making more PR's to fix most of these commands that either don't check for permissions/check if user is muted or not/what have you, or either just throw api errors because of it.